### PR TITLE
add msa-calamari to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,23 @@
 version: "3.9"
 
 services:
+  msa-calamari:
+    hostname: msa-calamari
+    build:
+      context: ocr4all-app-calamari-msa
+      dockerfile: Dockerfile
+      args:
+        - TAG=${CALAMARI_TAG:-20240502}
+        - JAVA_VERSION=${CALAMARI_JAVA_VERSION:-17}
+        - APP_VERSION=${CALAMARI_APP_VERSION:-1.0-SNAPSHOT}
+    user: "${UID:-}"
+    restart: always
+    environment:
+      -
+    volumes:
+      -
+    ports:
+      - "${OCRD_API_PORT:-127.0.0.1:9092}:8080"
   msa-ocrd:
     hostname: msa-ocrd
     build:


### PR DESCRIPTION
Adds msa-calamari to the docker-compose file, corresponding Dockerfile was already added in [e5170eb](https://github.com/OCR4all/ocr4all-app-calamari-msa/commit/e5170ebcb261001cd11d33edc08c5fa74031309f).
Volumes and env variables still have to be added.